### PR TITLE
Updating installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you are using Rails, you can add a sample *config/robots.rb* configuration fi
 
     $ rails g human_power:install
 
-It will allow crawlers access to the whole site by default.
+It will allow crawlers access to the whole site by default. Make sure you get rid of the static `robots.txt` that's residing in `/public`
 
 Now you can restart your server and visit `/robots.txt` to see what's generated from the new configuration file.
 


### PR DESCRIPTION
Important installation step: need to remove default 'robots.txt' from `/public` before generating a new one via `robots.rb`
