### PR TITLE
Add bundler 2.x and rails 5.x support

### DIFF
--- a/human_power.gemspec
+++ b/human_power.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^test/})
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "bundler", "~> 1.3"
+  s.add_development_dependency "bundler", "~> 2.2"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rails", "~> 4.0.1"
+  s.add_development_dependency "rails", "~> 5.2.2"
   s.add_development_dependency "sqlite3"
 end

--- a/lib/human_power/rails/controller.rb
+++ b/lib/human_power/rails/controller.rb
@@ -8,7 +8,7 @@ module HumanPower
         end
 
         # render text: something does not give correct content type
-        render text: generator.render, content_type: Mime::TEXT
+        render text: generator.render, content_type: Mime[:text]
       end
     end
   end

--- a/lib/human_power/rails/controller.rb
+++ b/lib/human_power/rails/controller.rb
@@ -7,8 +7,7 @@ module HumanPower
           instance_eval open(file).read, file
         end
 
-        # render text: something does not give correct content type
-        render text: generator.render, content_type: Mime[:text]
+        render plain: generator.render
       end
     end
   end

--- a/lib/human_power/version.rb
+++ b/lib/human_power/version.rb
@@ -1,3 +1,3 @@
 module HumanPower
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/lib/human_power/version.rb
+++ b/lib/human_power/version.rb
@@ -1,3 +1,3 @@
 module HumanPower
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
This PR makes the following changes:

 * Bump bundler to 2.2.x
 * Bump Rails to 5.2.2
 * Use `render plain:` instead of deprecated `Mime::TEXT`
 * Bump gem version to 0.2.1